### PR TITLE
Usage of variables for the binary builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ Goals of project:
 - Apply and learn modularity of GO
 - ..... tbc
 
-- What to configure for other cosmos projects than elys:
-main.go:
+> What to configure for other cosmos projects than elys:
+- main.go:
 api_addr
 
-package\internals:
-var binary
-var github_repo
+- package\internals:
+var binary & var github_repo
 
 ![Alt text](img/wda.png?raw=true "Title")

--- a/README.md
+++ b/README.md
@@ -8,4 +8,12 @@ Goals of project:
 - Apply and learn modularity of GO
 - ..... tbc
 
+- What to configure for other cosmos projects than elys:
+main.go:
+api_addr
+
+package\internals:
+var binary
+var github_repo
+
 ![Alt text](img/wda.png?raw=true "Title")

--- a/internals/binary_builder.go
+++ b/internals/binary_builder.go
@@ -6,15 +6,18 @@ import (
 	"os/exec"
 )
 
+var binary = "elys"
+var github_repo = "https://github.com/elys-network/elys.git"
+
 func BinaryBuild(version string) {
 	log.Println("Building the binary...")
 	cmds := []string{
-		"cd $HOME && rm -rf elys",
-		"cd $HOME && git clone https://github.com/elys-network/elys.git",
-		"cd $HOME/elys && git pull && git checkout " + version,
-		"cd $HOME/elys && make install",
-		"mkdir -p $HOME/.elys/cosmovisor/upgrades/" + version + "/bin",
-		"cp -a ~/go/bin/elysd ~/.elys/cosmovisor/upgrades/" + version + "/bin/elysd",
+		"cd $HOME && rm -rf " + binary,
+		"cd $HOME && git clone " + github_repo,
+		"cd $HOME/" + binary + " && git pull && git checkout " + version,
+		"cd $HOME/" + binary + " && make install",
+		"mkdir -p $HOME/." + binary +"/cosmovisor/upgrades/" + version + "/bin",
+		"cp -a ~/go/bin/" + binary + "d ~/." + binary + "/cosmovisor/upgrades/" + version + "/bin/" + binary + "d",
 	}
 
 	for _, cmdStr := range cmds {


### PR DESCRIPTION
In package/internals we can now set:
var binary
var github_repo
to make it easier to use for other cosmos based blockchains.